### PR TITLE
Because NiFi now enforces HTTPS w/ SUA, it's required to constrain th…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,7 +186,7 @@ services:
         ipv4_address: 172.27.1.17  
 
   nifi:
-    image: apache/nifi:latest
+    image: apache/nifi:1.12.0
     container_name: nifi
     ports:
       - 9999:9999


### PR DESCRIPTION
Because NiFi now enforces HTTPS w/ SUA, it's required to constrain the version to 1.12.0 (for while)